### PR TITLE
add distilbert support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Here is what GPU inference times are looking like
 from fitbert import FitBert
 
 
-# in theory you can pass a model_name and tokenizer, but currently only
-# bert-large-uncased and BertTokenizer are available
+# in theory you can pass a model_name and tokenizer
+# currently supported models: bert-large-uncased and distilbert-base-uncased
 # this takes a while and loads a whole big BERT into memory
 fb = FitBert()
 
@@ -71,11 +71,12 @@ filled_in = fb.fitb(masked_string, options=options)
 filled_in = fb.fitb(masked_string, options=options, delemmatize=True)
 ```
 
-If you are already using `pytorch_pretrained_bert.BertForMaskedLM`, and have an instance of BertForMaskedLM already instantiated, you can pass pass it in to reuse it:
+If you are already using `pytorch_pretrained_bert.BertForMaskedLM`, or `transformers.BertForMaskedLM` and have an instance of BertForMaskedLM already instantiated, you can pass pass it in to reuse it:
 
 ```python
 BLM = pytorch_pretrained_bert.BertForMaskedLM.from_pretrained(model_name)
-
+# or
+BLM = transfomers.BertForMaskedLM.from_pretrained(model_name)
 fb = FitBert(model=BLM)
 ```
 

--- a/fitbert/fitb.py
+++ b/fitbert/fitb.py
@@ -5,7 +5,13 @@ import torch
 from fitbert.delemmatize import Delemmatizer
 from fitbert.utils import mask as _mask
 from functional import pseq, seq
-from transformers import BertForMaskedLM, BertTokenizer, DistilBertForMaskedLM, DistilBertTokenizer
+from transformers import (
+    BertForMaskedLM,
+    BertTokenizer,
+    DistilBertForMaskedLM,
+    DistilBertTokenizer,
+)
+
 
 class FitBert:
     def __init__(
@@ -29,6 +35,7 @@ class FitBert:
                 self.bert = DistilBertForMaskedLM.from_pretrained(model_name)
             else:
                 self.bert = BertForMaskedLM.from_pretrained(model_name)
+            self.bert.to(self.device)
         else:
             self.bert = model
 
@@ -39,8 +46,7 @@ class FitBert:
                 self.tokenizer = BertTokenizer.from_pretrained(model_name)
         else:
             self.tokenizer = tokenizer
-                    
-        self.bert.to(self.device)
+
         self.bert.eval()
 
     @staticmethod

--- a/fitbert/fitb.py
+++ b/fitbert/fitb.py
@@ -5,8 +5,7 @@ import torch
 from fitbert.delemmatize import Delemmatizer
 from fitbert.utils import mask as _mask
 from functional import pseq, seq
-from pytorch_pretrained_bert import BertForMaskedLM, tokenization
-
+from transformers import BertForMaskedLM, BertTokenizer, DistilBertForMaskedLM, DistilBertTokenizer
 
 class FitBert:
     def __init__(
@@ -24,15 +23,24 @@ class FitBert:
         )
         print("using model:", model_name)
         print("device:", self.device)
+
         if not model:
-            self.bert = BertForMaskedLM.from_pretrained(model_name)
-            self.bert.to(self.device)
+            if "distilbert" in model_name:
+                self.bert = DistilBertForMaskedLM.from_pretrained(model_name)
+            else:
+                self.bert = BertForMaskedLM.from_pretrained(model_name)
         else:
             self.bert = model
+
         if not tokenizer:
-            self.tokenizer = tokenization.BertTokenizer.from_pretrained(model_name)
+            if "distilbert" in model_name:
+                self.tokenizer = DistilBertTokenizer.from_pretrained(model_name)
+            else:
+                self.tokenizer = BertTokenizer.from_pretrained(model_name)
         else:
             self.tokenizer = tokenizer
+                    
+        self.bert.to(self.device)
         self.bert.eval()
 
     @staticmethod
@@ -65,7 +73,7 @@ class FitBert:
 
         tens = torch.tensor(input_ids).to(self.device)
         with torch.no_grad():
-            preds = self.bert(tens)
+            preds = self.bert(tens)[0]
             probs = self.softmax(preds)
             tokens_ids = self.tokenizer.convert_tokens_to_ids(tokens)
             prob = (
@@ -103,7 +111,7 @@ class FitBert:
         tens = torch.tensor(input_ids).unsqueeze(0)
         tens = tens.to(self.device)
         with torch.no_grad():
-            preds = self.bert(tens)
+            preds = self.bert(tens)[0]
             probs = self.softmax(preds)
 
             pred_top = torch.topk(probs[0, target_idx], n)
@@ -136,7 +144,7 @@ class FitBert:
         tens = torch.tensor(input_ids).unsqueeze(0)
         tens = tens.to(self.device)
         with torch.no_grad():
-            preds = self.bert(tens)
+            preds = self.bert(tens)[0]
             probs = self.softmax(preds)
 
             ranked_pairs = (

--- a/fitbert/tests.py
+++ b/fitbert/tests.py
@@ -44,7 +44,7 @@ def test_masker_works_without_instantiating():
 
 @pytest.mark.slow
 def test_ranking():
-    fb = FitBert()
+    fb = FitBert(model_name="distilbert-base-uncased")
     assert callable(fb.fitb)
 
     sentences = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 torch>=1.1.0
-pytorch-pretrained-bert>=0.6.2
+transformers>=2.1.1
 PyFunctional==1.2.0


### PR DESCRIPTION
- migrate from `pytorch-pretrained-bert` to `transformers`
- add `DistiBERT` support
- use `distilbert-base-uncased` in test