### PR TITLE
Fix PyTorch device error when loading custom model

### DIFF
--- a/fitbert/fitb.py
+++ b/fitbert/fitb.py
@@ -27,16 +27,17 @@ class FitBert:
         self.device = torch.device(
             "cuda" if torch.cuda.is_available() and not disable_gpu else "cpu"
         )
-        print("using model:", model_name)
         print("device:", self.device)
 
         if not model:
+            print("using model:", model_name)
             if "distilbert" in model_name:
                 self.bert = DistilBertForMaskedLM.from_pretrained(model_name)
             else:
                 self.bert = BertForMaskedLM.from_pretrained(model_name)
             self.bert.to(self.device)
         else:
+            print("using custom model:", model.config.architectures)
             self.bert = model
             self.bert.to(self.device)
             

--- a/fitbert/fitb.py
+++ b/fitbert/fitb.py
@@ -38,7 +38,8 @@ class FitBert:
             self.bert.to(self.device)
         else:
             self.bert = model
-
+            self.bert.to(self.device)
+            
         if not tokenizer:
             if "distilbert" in model_name:
                 self.tokenizer = DistilBertTokenizer.from_pretrained(model_name)


### PR DESCRIPTION
Using Python 3.8, fitbert 0.7.0, transformers 2.9.1, torch 1.5.0 

when loading a custom Transformers model as described in the readme using:
`BertForMaskedLM.from_pretrained('path to pretrained')`

A runtime error occurs: 
_Expected object of device type cuda but got device type cpu for argument #1 'self' in call to _th_index_select__

The issue occurs at line 151: `tens = tens.to(self.device)`

but adding `self.bert.to(self.device)` to line 41 fixes this issue